### PR TITLE
fix: sanitize waypoint repository inputs

### DIFF
--- a/src/composables/useWaypointActions.ts
+++ b/src/composables/useWaypointActions.ts
@@ -1,7 +1,8 @@
+import type { LatLng } from '@/types/latlng';
 import { useWaypoints } from '@/stores/useWaypoints';
 import { useActions } from './useActions';
 
-type Point = { name: string; lat: number; lon: number; elev_m: number | null };
+type Point = { name: string; latLng: LatLng; elev_m: number | null };
 
 /**
  * Wrap common waypoint actions with toasts and store updates.

--- a/src/pages/DebugPage.vue
+++ b/src/pages/DebugPage.vue
@@ -163,7 +163,7 @@ import { useWaypoints } from '@/stores/useWaypoints';
 import { locationStream, providerRegistry, type LocationStreamMetaEvent } from '@/data/streams/location';
 import { useActions } from '@/composables/useActions';
 import { Heading } from '@/plugins/heading';
-import type { ProviderKind } from '@/types';
+import { toLatLng, type ProviderKind } from '@/types';
 import { usePermissionAlert } from '@/composables/usePermissionAlert';
 
 type Fix = {
@@ -489,7 +489,11 @@ async function runDiagnostics ()
   let tempId: number | null = null;
   try
   {
-    tempId = await wps.$repos.waypoints.create({ name: `diag-${ Date.now() }`, lat: 0, lon: 0, elev_m: null } as any);
+    tempId = await wps.$repos.waypoints.create({
+      name: `diag-${ Date.now() }`,
+      latLng: toLatLng(0, 0),
+      elev_m: null
+    });
     out.createOk = Number.isFinite(tempId);
   } catch (e: any)
   {

--- a/src/pages/GpsPage.vue
+++ b/src/pages/GpsPage.vue
@@ -535,8 +535,7 @@ async function markWaypoint ()
   }
   const point = {
     name: `WP ${ new Date().toLocaleTimeString() }`,
-    lat: gps.value.lat,
-    lon: gps.value.lon,
+    latLng: toLatLng(gps.value.lat, gps.value.lon),
     elev_m: null,
   };
   try

--- a/src/pages/TrailsPage.vue
+++ b/src/pages/TrailsPage.vue
@@ -95,6 +95,7 @@ import PageHeaderToolbar from '@/components/PageHeaderToolbar.vue';
 import { useActions } from '@/composables/useActions';
 import { useTrails } from '@/stores/useTrails';
 import { useWaypoints } from '@/stores/useWaypoints';
+import { toLatLng } from '@/types';
 import { exportTrailToGpx } from '@/data/storage/gpx/gpx.service';
 import MultiSelectWizard from '@/components/modals/MultiSelectWizard.vue';
 import type { MultiSelectConfig, MultiSelectItem } from '@/types/multi-select';
@@ -244,7 +245,11 @@ function handleAddWaypoint(data: any, payload?: AddWaypointPayload): boolean {
     return false;
   }
   (async () => {
-    await wps.addToTrail(payload.trailId, { name, lat, lon, elev_m: elev ?? undefined });
+    await wps.addToTrail(payload.trailId, {
+      name,
+      latLng: toLatLng(lat, lon),
+      elev_m: elev ?? undefined
+    });
     await wps.loadForTrail(payload.trailId);
     actions.show('Waypoint added', { kind: 'success' });
   })();

--- a/src/pages/WaypointsPage.vue
+++ b/src/pages/WaypointsPage.vue
@@ -237,7 +237,7 @@ function handleAddConfirm (data: any): boolean
   // Fire async creation and allow alert to close immediately
   (async () =>
   {
-    const id = await wps.create({ name, lat, lon, elev_m: elev });
+    const id = await wps.create({ name, latLng: toLatLng(lat, lon), elev_m: elev });
     await wps.refreshAll();
     if (liveUpdates.value || Object.keys(distances.value).length > 0) { await refreshDistances(); }
     actionsService.show('Waypoint added', {
@@ -283,7 +283,7 @@ function handleEditConfirm (data: any, payload?: EditAlertPayload): boolean
   {
     const id = payload.id;
     const prev = payload.prevSnapshot ? { ...payload.prevSnapshot } : null;
-    await wps.update(id, { name, lat, lon, elev_m: elev });
+    await wps.update(id, { name, latLng: toLatLng(lat, lon), elev_m: elev });
     await wps.refreshAll();
     if (liveUpdates.value || Object.keys(distances.value).length > 0)
     {
@@ -294,7 +294,11 @@ function handleEditConfirm (data: any, payload?: EditAlertPayload): boolean
       canUndo: !!prev,
       onUndo: prev ? async () =>
       {
-        await wps.update(id, { name: prev.name, lat: prev.lat, lon: prev.lon, elev_m: prev.elev_m ?? null });
+        await wps.update(id, {
+          name: prev.name,
+          latLng: toLatLng(prev.lat, prev.lon),
+          elev_m: prev.elev_m ?? null
+        });
         await wps.refreshAll();
       } : undefined
     });
@@ -330,7 +334,11 @@ function handleDeleteConfirm (payload?: DeleteAlertPayload): boolean
       canUndo: !!snap,
       onUndo: snap ? async () =>
       {
-        await wps.create({ name: snap.name, lat: snap.lat, lon: snap.lon, elev_m: snap.elev_m ?? null });
+        await wps.create({
+          name: snap.name,
+          latLng: toLatLng(snap.lat, snap.lon),
+          elev_m: snap.elev_m ?? null
+        });
         await wps.refreshAll();
       } : undefined
     });

--- a/src/stores/useWaypoints.ts
+++ b/src/stores/useWaypoints.ts
@@ -12,7 +12,7 @@ export const useWaypoints = defineStore('waypoints', {
     async refreshAll() {
       this.all = await this.$repos.waypoints.all();
     },
-    async create(input: { name: string; lat: number; lon: number; elev_m?: number | null }) {
+    async create(input: { name: string; latLng: LatLng; elev_m?: number | null }) {
       const id = await this.$repos.waypoints.create(input);
       await this.refreshAll();
       return id;
@@ -20,7 +20,7 @@ export const useWaypoints = defineStore('waypoints', {
     async loadForTrail(trailId: number) {
       this.byTrail[trailId] = await this.$repos.waypoints.forTrail(trailId);
     },
-    async addToTrail(trailId: number, input: { name: string; lat: number; lon: number; elev_m?: number | null; position?: number }) {
+    async addToTrail(trailId: number, input: { name: string; latLng: LatLng; elev_m?: number | null; position?: number }) {
       const { waypointId } = await this.$repos.waypoints.addToTrail({ trailId, ...input });
       await this.loadForTrail(trailId);
       return waypointId;
@@ -40,7 +40,7 @@ export const useWaypoints = defineStore('waypoints', {
     async rename(id: number, name: string) {
       await this.$repos.waypoints.rename(id, name);
     },
-    async update(id: number, patch: { name?: string; lat?: number; lon?: number; elev_m?: number | null; description?: string | null }) {
+    async update(id: number, patch: { name?: string; latLng?: LatLng; elev_m?: number | null; description?: string | null }) {
       await this.$repos.waypoints.update(id, patch);
     },
     async remove(id: number) {

--- a/tests/unit/trails.repo.spec.ts
+++ b/tests/unit/trails.repo.spec.ts
@@ -3,6 +3,7 @@ import { createTestDb } from '@/db/factory';
 import { webDbAvailable } from './fixtures/test-db';
 import { TrailsRepo } from '@/data/repositories/trails.repo';
 import { WaypointsRepo } from '@/data/repositories/waypoints.repo';
+import { toLatLng } from '@/types/latlng';
 
 describe.skipIf(!webDbAvailable())('TrailsRepo', () => {
   it('creates and removes trail with cascade', async () => {
@@ -10,7 +11,7 @@ describe.skipIf(!webDbAvailable())('TrailsRepo', () => {
     const trails = new TrailsRepo(db);
     const waypoints = new WaypointsRepo(db);
     const trailId = await trails.create({ name: 'Test' });
-    await waypoints.addToTrail({ trailId, name: 'WP', lat: 0, lon: 0 });
+    await waypoints.addToTrail({ trailId, name: 'WP', latLng: toLatLng(0, 0) });
     expect((await trails.all()).length).toBe(1);
     await trails.remove(trailId);
     expect((await trails.all()).length).toBe(0);

--- a/tests/unit/waypoints.repo.native.spec.ts
+++ b/tests/unit/waypoints.repo.native.spec.ts
@@ -3,6 +3,7 @@ import { Kysely, SqliteDialect } from 'kysely';
 import type { DB } from '@/db/schema';
 import { createMigrator } from '@/db/migrations/provider';
 import { WaypointsRepo } from '@/data/repositories/waypoints.repo';
+import { toLatLng } from '@/types/latlng';
 
 // Old/native path using better-sqlite3(':memory:').
 // Gated to run only when DB_NATIVE=1 is set.
@@ -40,7 +41,7 @@ describe.skipIf(!DB_NATIVE_ENABLED || !NATIVE_AVAILABLE)('WaypointsRepo DB (nati
   it('creates and lists a waypoint (timed)', async () => {
     const start = Date.now();
     const repo = new WaypointsRepo(db as any);
-    const id = await repo.create({ name: 'Valid', lat: 12.34, lon: 56.78 });
+    const id = await repo.create({ name: 'Valid', latLng: toLatLng(12.34, 56.78) });
     expect(id).toBeGreaterThan(0);
     const all = await (db as Kysely<DB>)
       .selectFrom('waypoint')

--- a/tests/unit/waypoints.repo.spec.ts
+++ b/tests/unit/waypoints.repo.spec.ts
@@ -1,18 +1,27 @@
 import { describe, it, expect } from 'vitest';
 import { WaypointsRepo } from '@/data/repositories/waypoints.repo';
+import { toLatLng } from '@/types/latlng';
 import { webDbAvailable, defineDbLifecycle } from './fixtures/test-db';
 
 describe('WaypointsRepo.create validation', () => {
   it('rejects latitude outside [-90, 90]', async () => {
     const repo = new WaypointsRepo({} as any);
-    await expect(repo.create({ name: 'WP', lat: 100, lon: 0 })).rejects.toThrow(/Invalid coordinates/);
-    await expect(repo.create({ name: 'WP', lat: -91, lon: 0 })).rejects.toThrow(/Invalid coordinates/);
+    await expect(
+      repo.create({ name: 'WP', latLng: { lat: 100, lon: 0 } as any })
+    ).rejects.toThrow(/Invalid/);
+    await expect(
+      repo.create({ name: 'WP', latLng: { lat: -91, lon: 0 } as any })
+    ).rejects.toThrow(/Invalid/);
   });
 
   it('rejects longitude outside [-180, 180]', async () => {
     const repo = new WaypointsRepo({} as any);
-    await expect(repo.create({ name: 'WP', lat: 0, lon: 181 })).rejects.toThrow(/Invalid coordinates/);
-    await expect(repo.create({ name: 'WP', lat: 0, lon: -181 })).rejects.toThrow(/Invalid coordinates/);
+    await expect(
+      repo.create({ name: 'WP', latLng: { lat: 0, lon: 181 } as any })
+    ).rejects.toThrow(/Invalid/);
+    await expect(
+      repo.create({ name: 'WP', latLng: { lat: 0, lon: -181 } as any })
+    ).rejects.toThrow(/Invalid/);
   });
 });
 
@@ -24,7 +33,7 @@ describe.skipIf(!webDbAvailable())('WaypointsRepo DB (web jeep-sqlite)', () => {
     const start = Date.now();
     const db = getDb();
     const repo = new WaypointsRepo(db as any);
-    const id = await repo.create({ name: 'Valid', lat: 12.34, lon: 56.78 });
+    const id = await repo.create({ name: 'Valid', latLng: toLatLng(12.34, 56.78) });
     expect(id).toBeGreaterThan(0);
     const all = await db.selectFrom('waypoint').selectAll().execute();
     const end = Date.now();


### PR DESCRIPTION
## Summary
- document the waypoint repository and require LatLng values for its public methods
- update stores, pages, and diagnostics to create and update waypoints with validated coordinates
- refresh unit tests to cover the stricter inputs and transactional behaviour

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d662352270832a8a9f2263dc7c5312